### PR TITLE
Init CAN with custom SPI pins

### DIFF
--- a/mcp_can.cpp
+++ b/mcp_can.cpp
@@ -621,6 +621,20 @@ byte MCP_CAN::begin(byte speedset)
 }
 
 /*********************************************************************************************************
+** Function name:           init
+** Descriptions:            init can and set SPI pins and CAN speed
+*********************************************************************************************************/
+byte MCP_CAN::begin(int8_t sclk, int8_t miso, int8_t mosi, int8_t ss, byte speedset)
+{
+
+    pinMode(SPICS, OUTPUT);
+    MCP2515_UNSELECT();
+    SPI.begin(sclk, miso, mosi, ss);
+    byte res = mcp2515_init(speedset);
+    return ((res == MCP2515_OK) ? CAN_OK : CAN_FAILINIT);
+}
+
+/*********************************************************************************************************
 ** Function name:           init_Mask
 ** Descriptions:            init canid Masks
 *********************************************************************************************************/
@@ -746,9 +760,10 @@ byte MCP_CAN::init_Filt(byte num, byte ext, unsigned long ulData)
 *********************************************************************************************************/
 byte MCP_CAN::setMsg(unsigned long id, byte ext, byte len, byte rtr, byte *pData)
 {
+    byte tmp = MAX_CHAR_IN_MESSAGE;
     ext_flg     = ext;
     can_id      = id;
-    dta_len     = min(len, MAX_CHAR_IN_MESSAGE);
+    dta_len     = min(len, tmp);
     rtr         = rtr;
     for(int i = 0; i<dta_len; i++)
     {

--- a/mcp_can.h
+++ b/mcp_can.h
@@ -98,6 +98,7 @@ private:
 public:
     MCP_CAN(byte _CS);
     byte begin(byte speedset);                                      // init can
+    byte begin(int8_t sclk, int8_t miso, int8_t mosi, int8_t ss, byte speedset);// init can with SPI pins
     byte init_Mask(byte num, byte ext, unsigned long ulData);       // init Masks
     byte init_Filt(byte num, byte ext, unsigned long ulData);       // init filters
     byte sendMsgBuf(unsigned long id, byte ext, byte rtr, byte len, byte *buf);     // send buf


### PR DESCRIPTION
added begin() overload for SPI pin config in order to use the library on ESP32 running arduino framework